### PR TITLE
Refactor/refactor wind store

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -64,10 +64,6 @@ TimeSheet {
   z-index: 2;
 }
 
-Loader {
-  z-index: 5;
-}
-
 Menu,
 Viewbar {
   z-index: 7;

--- a/src/Login.vue
+++ b/src/Login.vue
@@ -59,7 +59,7 @@ export default {
       const loginResult = await this.$store.dispatch("connect", userdata);
       this.authenticated = loginResult.authenticated;
       if (this.authenticated) {
-        this.context = loginResult.context;
+        this.context = loginResult.context || "grasbrook";
         this.restrictedAccess = loginResult.restricted;
         this.applyCustomMapSettings();
 

--- a/src/components/Loader/Loader.vue
+++ b/src/components/Loader/Loader.vue
@@ -1,35 +1,55 @@
-<script>
+<script lang="ts">
 import { mapState } from "vuex";
+import { Component, Vue } from "vue-property-decorator";
+import { Store } from "vuex";
+import { DataLoadingStati, ScenarioComponentName, StoreStateWithModules } from "@/models";
 
-export default {
-  name: "Contextmenu",
-  components: {},
-  data() {
-    return {
-      loading: this.loader,
-    };
-  },
-  computed: {
-    ...mapState(["allFeaturesHighlighted", "map"]),
-    loader() {
-      return this.$store.state.scenario.loader;
-    },
-    loaderTxt() {
-      return this.$store.state.scenario.loaderTxt;
-    },
-  },
-  watch: {
-    loader(val) {
-      console.log("iam logging", val);
-      this.loading = val;
-    },
-  },
-  methods: {},
-};
+
+@Component({
+  name: "LoaderScreen",
+  components: {}
+})
+
+export default class LoaderScreen extends Vue {
+    $store: Store<StoreStateWithModules>;
+
+    // TODO rename menucomponent to scenarioComponent
+    get activeScenarioComponent(): string {
+    return this.$store.state.activeMenuComponent;
+    }
+
+    get dataLoadingStati(): DataLoadingStati {
+      return this.$store.state.scenario.resultLoadingStati;
+    }
+
+    /** show loader if result data for the current scenario component is loading - or for general/misc data loading */
+    get showLoader(): boolean {
+      return this.dataLoadingStati[this.activeScenarioComponent] || this.dataLoadingStati.map
+    }
+
+    get loaderTxt(): string {
+      if (this.dataLoadingStati.map) {
+        return "....Loading...Please wait.."
+      }
+
+      const loaderTexts: Record<ScenarioComponentName, string> = {
+        sun: "Fetching sun exposure results. May take up to 2 min.",
+        wind: "Fetching wind comfort results. May take up to 2 min.",
+        noise: "Fetching traffic noise results. May take up to 2 min.",
+        pedestrian: "Fetching ABM results. May take up to 2 min.",
+        stormwater: "Fetching stormwater results. May take up to 30sec.",
+        multiLayer: "Calculation in progress. May take up to 2 min.",
+      }
+
+      return loaderTexts[this.activeScenarioComponent]
+    }
+
+}
 </script>
 
+
 <template>
-  <div id="big_loader" :class="loading ? '' : 'hidden'">
+  <div id="big_loader" :class="showLoader ? '' : 'hidden'">
     <div class="css-loader">
       <div></div>
       <div></div>
@@ -49,7 +69,7 @@ export default {
   left: 0;
   width: 100vw;
   height: 100vh;
-  z-index: 3;
+  z-index: 1;
   backdrop-filter: blur(5px) saturate(180%);
   transform: scale(1);
   background: radial-gradient(

--- a/src/components/Loader/Loader.vue
+++ b/src/components/Loader/Loader.vue
@@ -27,23 +27,23 @@ export default class LoaderScreen extends Vue {
       return this.dataLoadingStati[this.activeScenarioComponent] || this.dataLoadingStati.map
     }
 
+    /** looks for which loading status is true and returns associated text */
     get loaderTxt(): string {
       if (this.dataLoadingStati.map) {
         return "....Loading...Please wait.."
       }
 
       const loaderTexts: Record<ScenarioComponentName, string> = {
-        sun: "Fetching sun exposure results. May take up to 2 min.",
-        wind: "Fetching wind comfort results. May take up to 2 min.",
-        noise: "Fetching traffic noise results. May take up to 2 min.",
-        pedestrian: "Fetching ABM results. May take up to 2 min.",
-        stormwater: "Fetching stormwater results. May take up to 30sec.",
-        multiLayer: "Calculation in progress. May take up to 2 min.",
+        sun: "Fetching sun exposure results.",
+        wind: "Fetching wind-comfort results from Infrared.",
+        noise: "Fetching traffic noise results.",
+        pedestrian: "Fetching ABM results.",
+        stormwater: "Fetching stormwater results.",
+        multiLayer: "Calculation in progress.",
       }
 
       return loaderTexts[this.activeScenarioComponent]
     }
-
 }
 </script>
 

--- a/src/components/Map/Map.vue
+++ b/src/components/Map/Map.vue
@@ -41,6 +41,21 @@ export default {
     heatMapActive() {
       return this.$store.state.scenario.heatMap;
     },
+    showLoader: {
+      // getter
+      get: function () {
+      return this.$store.state.scenario.resultLoadingStati.map
+      },
+      // setter
+      set: function (loadingState) {
+        let loadingStati = Object.assign(
+          {}, 
+          this.$store.state.scenario.resultLoadingStati
+        );
+        loadingStati.map = loadingState;
+        this.$store.commit("scenario/resultLoadingStati", loadingStati);
+      }
+    },
   },
   mounted(): void {
     mapboxgl.accessToken = this.accessToken;
@@ -146,7 +161,9 @@ export default {
     },
     onMapLoaded() {
       console.log("create design layers");
-      this.$store.dispatch("createDesignLayers");
+      this.showLoader = true;
+      this.$store.dispatch("createDesignLayers")
+        .then(() => { this.showLoader = false; } );
       this.$store.dispatch("addFocusAreasMapLayer");
     },
     createModal() {

--- a/src/components/Menu/Menu.vue
+++ b/src/components/Menu/Menu.vue
@@ -2,9 +2,10 @@
 import AbmScenario from "@/components/Scenario/AbmScenario.vue";
 import StormwaterScenario from "@/components/Scenario/StormwaterScenario.vue";
 import NoiseScenario from "@/components/Scenario/NoiseScenario.vue";
-import SunExposureResults from "@/components/Scenario/SunExposure.vue";
+import SunExposureScenario from "@/components/Scenario/SunExposure.vue";
 import WindScenario from "@/components/Scenario/Wind.vue";
 import MultiLayerAnalysis from "@/components/Scenario/MultiLayerAnalysis.vue";
+import scenarioComponentNames from "@/config/scenarioComponentNames";
 
 export default {
   name: "Menu",
@@ -13,7 +14,7 @@ export default {
     StormwaterScenario,
     NoiseScenario,
     WindScenario,
-    SunExposureResults,
+    SunExposureScenario,
     MultiLayerAnalysis,
   },
   props: {
@@ -24,6 +25,7 @@ export default {
     return {
       windowWidth: window.innerWidth,
       menuOpen: false,
+      componentNames: {...scenarioComponentNames}
     };
   },
   computed: {
@@ -72,49 +74,47 @@ export default {
           <ul class="component_list">
             <li
               class="component_link"
-              v-bind:class="{ highlight: activeComponent === 'AbmScenario' }"
-              @click="activeComponent = 'AbmScenario'"
+              v-bind:class="{ highlight: activeComponent === componentNames.pedestrian }"
+              @click="activeComponent = componentNames.pedestrian"
             >
               <p>Pedestrians</p>
             </li>
             <li
               class="component_link"
               v-bind:class="{
-                highlight: activeComponent === 'StormwaterScenario',
+                highlight: activeComponent === componentNames.stormwater,
               }"
-              @click="activeComponent = 'StormwaterScenario'"
+              @click="activeComponent = componentNames.stormwater"
             >
               <p>Stormwater</p>
             </li>
             <li
               class="component_link"
-              v-bind:class="{ highlight: activeComponent === 'NoiseScenario' }"
-              @click="activeComponent = 'NoiseScenario'"
+              v-bind:class="{ highlight: activeComponent === componentNames.noise }"
+              @click="activeComponent = componentNames.noise"
             >
               <p>Noise</p>
             </li>
             <li
               class="component_link"
-              v-bind:class="{ highlight: activeComponent === 'WindScenario' }"
-              @click="activeComponent = 'WindScenario'"
+              v-bind:class="{ highlight: activeComponent === componentNames.wind }"
+              @click="activeComponent = componentNames.wind"
             >
               <p>Wind</p>
             </li>
             <li
               class="component_link"
-              v-bind:class="{
-                highlight: activeComponent === 'SunExposureResults',
-              }"
-              @click="activeComponent = 'SunExposureResults'"
+              v-bind:class="{ highlight: activeComponent === componentNames.sun }"
+              @click="activeComponent = componentNames.sun"
             >
               <p>Sun</p>
             </li>
             <li
               class="component_link"
               v-bind:class="{
-                highlight: activeComponent === 'MultiLayerAnalysis',
+                highlight: activeComponent === componentNames.multiLayer,
               }"
-              @click="activeComponent = 'MultiLayerAnalysis'"
+              @click="activeComponent = componentNames.multiLayer"
             >
               <p>Combine Layers</p>
             </li>
@@ -122,35 +122,35 @@ export default {
         </template>
         <template v-else>
           <select class="mobile_select" v-model="activeComponent">
-            <option value="AbmScenario">Pedestrians</option>
-            <option value="StormwaterScenario">Stormwater</option>
-            <option value="NoiseScenario">Noise</option>
-            <option value="WindScenario">Wind</option>
-            <option value="SunExposureResults">Sun</option>
-            <option value="MultiLayerAnalysis">Combine Layers</option>
+            <option :value="componentNames.pedestrian">Pedestrians</option>
+            <option :value="componentNames.stormwater">Stormwater</option>
+            <option :value="componentNames.noise">Noise</option>
+            <option :value="componentNames.wind">Wind</option>
+            <option :value="componentNames.sun">Sun</option>
+            <option :value="componentNames.multiLayer">Combine Layers</option>
           </select>
         </template>
       </div>
       <div class="body_scope">
-        <div v-if="activeComponent === 'AbmScenario'">
+        <div v-if="activeComponent === componentNames.pedestrian">
           <AbmScenario
             :restrictedAccess="restrictedAccess"
             :context="context"
           />
         </div>
-        <div v-if="activeComponent === 'StormwaterScenario'">
+        <div v-if="activeComponent === componentNames.stormwater">
           <StormwaterScenario />
         </div>
-        <div v-if="activeComponent === 'NoiseScenario'">
+        <div v-if="activeComponent === componentNames.noise">
           <NoiseScenario />
         </div>
-        <div v-if="activeComponent === 'WindScenario'">
+        <div v-if="activeComponent === componentNames.wind">
           <WindScenario />
         </div>
-        <div v-if="activeComponent === 'SunExposureResults'">
-          <SunExposureResults />
+        <div v-if="activeComponent === componentNames.sun">
+          <SunExposureScenario/>
         </div>
-        <div v-if="activeComponent === 'MultiLayerAnalysis'">
+        <div v-if="activeComponent === componentNames.multiLayer">
           <MultiLayerAnalysis />
         </div>
       </div>

--- a/src/components/Scenario/MultiLayerAnalysis.vue
+++ b/src/components/Scenario/MultiLayerAnalysis.vue
@@ -360,6 +360,7 @@ export default {
     determineMissingScenarios() {
       // iterate over scenario results, if a result is empty add the topic to missing Input scenarios
       this.getResultsFromStore();
+      console.log("all simresults", this.allSimulationResults)
       this.missingInputScenarios = [];
       this.layersReadyToCompare = [];
       for (const [key, value] of Object.entries(this.allSimulationResults)) {
@@ -376,9 +377,10 @@ export default {
           await this.$store.dispatch("scenario/addSunExposureLayer");
           break;
         case "Wind":
-          this.currentWindScenario = { wind_speed: 5, wind_direction: 270 };
-          this.$store.dispatch("wind/triggerWindCalculation")
-            .then(() => { this.$store.dispatch("wind/updateWindResult") })
+          await this.$store.dispatch("wind/triggerCalculation")
+            .then(async () => { 
+              await this.$store.dispatch("wind/fetchResult") 
+            })
           break;
         case "Noise":
           await this.$store.dispatch(

--- a/src/components/Scenario/MultiLayerAnalysis.vue
+++ b/src/components/Scenario/MultiLayerAnalysis.vue
@@ -118,7 +118,6 @@ export default {
       ["activeMenuComponent", "activeMenuComponent"],
       ["visibleLayers", "visibleLayers"],
       ["noiseScenario", "scenario/noiseScenario"],
-      ["currentWindScenario", "scenario/currentWindScenario"],
       ["windScenarioHash", "scenario/windScenarioHash"],
       ["abmSettings", "scenario/moduleSettings"],
     ]),
@@ -132,7 +131,10 @@ export default {
       return this.$store.state.scenario.currentNoiseGeoJson;
     },
     currentWindResult() {
-      return this.$store.state.scenario.windResultGeoJson;
+      return this.$store.getters["wind/windResult"];
+    },
+    currentWindScenario() {
+      return this.$store.getters["wind/scenarioConfiguration"];
     },
     currentSunResult() {
       return this.$store.state.scenario.sunExposureGeoJson;
@@ -374,9 +376,9 @@ export default {
           await this.$store.dispatch("scenario/addSunExposureLayer");
           break;
         case "Wind":
-          this.windScenarioHash = "158d2b824886d908440da5c5f6c4dc4f815cdeba";
           this.currentWindScenario = { wind_speed: 5, wind_direction: 270 };
-          await this.$store.dispatch("scenario/updateWindLayer");
+          this.$store.dispatch("wind/triggerWindCalculation")
+            .then(() => { this.$store.dispatch("wind/updateWindResult") })
           break;
         case "Noise":
           await this.$store.dispatch(

--- a/src/components/Scenario/NoiseScenario.vue
+++ b/src/components/Scenario/NoiseScenario.vue
@@ -5,10 +5,12 @@ import MenuComponentDivision from "@/components/Menu/MenuComponentDivision.vue";
 import type { MenuLink } from "@/models";
 import { mapState } from "vuex";
 import { hideAllLayersButThese, removeSourceAndItsLayersFromMap } from '@/services/map.service';
+import ScenarioComponentNames from '@/config/scenarioComponentNames';
+import { ScenegraphLayer } from '@deck.gl/mesh-layers';
 
 
 export default {
-  name: "NoiseScenario",
+  name: ScenarioComponentNames.noise,
   components: {
     Legend,
     MenuComponentDivision,
@@ -27,16 +29,29 @@ export default {
   },
   computed: {
      ...mapState(["map"]), // getter only
-    //...mapState('scenario', ['resultLoading']), // getter only
     // syntax for storeGetterSetter [variableName, get path, ? optional custom commit path]
     ...generateStoreGetterSetter([
       ["noiseMap", "scenario/" + "noiseMap"],
       ["noiseScenario", "scenario/noiseScenario"],
       ["savedNoiseScenarios", "scenario/" + "savedNoiseScenarios"], // todo manage stores
-      ["resultLoading", "scenario/" + "resultLoading"], // todo manage stores
       //['trafficPercent', 'scenario/noiseScenario/' + noiseSettingsNames.trafficPercent],
       //['maxSpeed', 'scenario/noiseScenario/' + noiseSettingsNames.maxSpeed],
     ]),
+    resultLoading: {
+      // getter
+      get: function () {
+      return this.$store.state.scenario.resultLoadingStati.noise
+      },
+      // setter
+      set: function (loadingState) {
+        let loadingStati = Object.assign(
+          {}, 
+          this.$store.state.scenario.resultLoadingStati
+        );
+        loadingStati.noise = loadingState;
+        this.$store.commit("scenario/resultLoadingStati", loadingStati);
+      }
+    },
     componentDivisions(): MenuLink[] {
       return [
         {
@@ -178,6 +193,7 @@ export default {
               max="1"
               dark
               flat
+              :disabled="resultLoading"
             ></v-slider>
           </div>
           <div class="scenario_box" :class="resultOutdated ? 'highlight' : ''">
@@ -186,8 +202,8 @@ export default {
               In project area
             </header>
             <v-radio-group v-model="maxSpeed">
-              <v-radio :value="30" flat label="30 kmh/h" dark />
-              <v-radio :value="50" flat label="50 kmh/h" dark />
+              <v-radio :value="30" flat label="30 kmh/h" dark :disabled="resultLoading"/>
+              <v-radio :value="50" flat label="50 kmh/h" dark :disabled="resultLoading"/>
             </v-radio-group>
           </div>
           <p v-if="showError" class="warning">{{ errMsg }}</p>
@@ -208,7 +224,7 @@ export default {
             "
             @click="saveNoiseScenario"
             class="confirm_btn"
-            :disabled="resultOutdated || scenarioAlreadySaved"
+            :disabled="resultOutdated || scenarioAlreadySaved || resultLoading"
             :dark="resultOutdated || scenarioAlreadySaved"
           >
             Save
@@ -235,6 +251,7 @@ export default {
                     outlined
                     dark
                     small
+                    :disabled="resultLoading"
                   >
                     <span v-if="scenario.label">
                       {{ scenario.label }}
@@ -249,11 +266,6 @@ export default {
             </v-data-iterator>
           </div>
         </v-container>
-
-        <v-overlay :value="resultLoading">
-          <div>Loading results</div>
-          <v-progress-linear style="margin-top: 50px">...</v-progress-linear>
-        </v-overlay>
       </div>
       <!--component_content end-->
     </div>

--- a/src/components/Scenario/NoiseScenario.vue
+++ b/src/components/Scenario/NoiseScenario.vue
@@ -112,7 +112,6 @@ export default {
           this.scenarioAlreadySaved = this.isScenarioAlreadySaved();
           if (!this.activeComponentIsNoise) {
             hideLayers(this.map, [NoiseResultLayerConfig.layerConfig.id])
-            alert("Noise is ready")
           }
         })
         .catch((err) => {

--- a/src/components/Scenario/NoiseScenario.vue
+++ b/src/components/Scenario/NoiseScenario.vue
@@ -4,9 +4,10 @@ import Legend from "@/components/Scenario/Legend.vue";
 import MenuComponentDivision from "@/components/Menu/MenuComponentDivision.vue";
 import type { MenuLink } from "@/models";
 import { mapState } from "vuex";
-import { hideAllLayersButThese, removeSourceAndItsLayersFromMap } from '@/services/map.service';
+import { hideAllLayersButThese, removeSourceAndItsLayersFromMap, hideLayers } from '@/services/map.service';
 import ScenarioComponentNames from '@/config/scenarioComponentNames';
 import { ScenegraphLayer } from '@deck.gl/mesh-layers';
+import NoiseResultLayerConfig from '@/config/calculationModuleResults/noiseResultLayerConfig';
 
 
 export default {
@@ -51,6 +52,9 @@ export default {
         loadingStati.noise = loadingState;
         this.$store.commit("scenario/resultLoadingStati", loadingStati);
       }
+    },
+    activeComponentIsNoise(): boolean {
+      return this.$store.state.activeMenuComponent === ScenarioComponentNames.noise;
     },
     componentDivisions(): MenuLink[] {
       return [
@@ -106,6 +110,10 @@ export default {
           this.resultLoading = false;
           this.resultOutdated = this.isResultOutdated();
           this.scenarioAlreadySaved = this.isScenarioAlreadySaved();
+          if (!this.activeComponentIsNoise) {
+            hideLayers(this.map, [NoiseResultLayerConfig.layerConfig.id])
+            alert("Noise is ready")
+          }
         })
         .catch((err) => {
           this.$store.commit("scenario/noiseMap", false);

--- a/src/components/Scenario/StormwaterScenario.vue
+++ b/src/components/Scenario/StormwaterScenario.vue
@@ -27,18 +27,21 @@
                 flat
                 :label="returnPeriodOptions[0].label"
                 dark
+                :disabled="resultLoading"
               />
               <v-radio
                 :value="returnPeriodOptions[1].value"
                 flat
                 :label="returnPeriodOptions[1].label"
                 dark
+                :disabled="resultLoading"
               />
               <v-radio
                 :value="returnPeriodOptions[2].value"
                 flat
                 :label="returnPeriodOptions[2].label"
                 dark
+                :disabled="resultLoading"
               />
             </v-radio-group>
           </div>
@@ -50,12 +53,14 @@
                 flat
                 :label="flowPathOptions[0].label"
                 dark
+                :disabled="resultLoading"
               />
               <v-radio
                 :value="flowPathOptions[1].value"
                 flat
                 :label="flowPathOptions[1].label"
                 dark
+                :disabled="resultLoading"
               />
             </v-radio-group>
           </div>
@@ -67,12 +72,14 @@
                 flat
                 :label="greenRoofOptions[0].label"
                 dark
+                :disabled="resultLoading"
               />
               <v-radio
                 :value="greenRoofOptions[1].value"
                 flat
                 :label="greenRoofOptions[1].label"
                 dark
+                :disabled="resultLoading"
               />
             </v-radio-group>
           </div>
@@ -86,11 +93,6 @@
             Run Scenario
           </v-btn>
         </v-container>
-
-        <v-overlay :value="resultLoading">
-          <div>Loading results</div>
-          <v-progress-linear>...</v-progress-linear>
-        </v-overlay>
       </div>
       <!--component content end -->
     </div>
@@ -164,14 +166,15 @@
 <script lang="ts">
 import MenuComponentDivision from "@/components/Menu/MenuComponentDivision.vue";
 import type { MenuLink, StormWaterScenarioConfiguration, StormWaterResult, MapboxMap } from "@/models";
-import { StoreStateWithModules } from "@/models";
 import { swLayerName } from "@/services/layers.service";
 import { Component, Vue } from "vue-property-decorator";
 import { Store } from "vuex";
+import { StoreStateWithModules } from "@/models";
 import { hideAllLayersButThese, removeSourceAndItsLayersFromMap } from "@/services/map.service";
-
+import ScenarioComponentNames from '@/config/scenarioComponentNames';
 
 @Component({
+  name: ScenarioComponentNames.stormwater,
   components: { MenuComponentDivision },
 })
 export default class StormwaterScenario extends Vue {
@@ -280,12 +283,20 @@ export default class StormwaterScenario extends Vue {
   }
 
   get resultLoading(): boolean {
-    return this.$store.state.scenario.resultLoading;
+    return this.$store.state.scenario.resultLoadingStati.stormwater;
   }
 
   set resultLoading(loadingState: boolean) {
-    this.$store.commit("scenario/resultLoading", loadingState);
+    let loadingStati = Object.assign(
+      {}, 
+      this.$store.state.scenario.resultLoadingStati
+    );
+    
+    loadingStati.stormwater = loadingState;
+
+    this.$store.commit("scenario/resultLoadingStati", loadingStati);
   }
+
 
   async loadStormwaterMap(): Promise<void> {
     this.resultLoading = true;

--- a/src/components/Scenario/SunExposure.vue
+++ b/src/components/Scenario/SunExposure.vue
@@ -7,9 +7,11 @@ import Legend from "@/components/Scenario/Legend.vue";
 import MenuComponentDivision from "@/components/Menu/MenuComponentDivision.vue";
 import type { MenuLink } from "@/models";
 import { hideAllLayersButThese } from '@/services/map.service';
+import ScenarioComponentNames from '@/config/scenarioComponentNames';
+
 
 export default {
-  name: "SunExposureResults",
+  name: ScenarioComponentNames.sun,
   components: {
     Legend,
     MenuComponentDivision,
@@ -29,6 +31,22 @@ export default {
     /*...generateStoreGetterSetter([
         ['resultLoading', 'scenario/' + 'resultLoading'],  // todo manage stores
       ])*/
+
+    resultLoading: {
+      // getter
+      get: function () {
+      return this.$store.state.scenario.resultLoadingStati.sun
+      },
+      // setter
+      set: function (loadingState) {
+        let loadingStati = Object.assign(
+          {}, 
+          this.$store.state.scenario.resultLoadingStati
+        );
+        loadingStati.sun = loadingState;
+        this.$store.commit("scenario/resultLoadingStati", loadingStati);
+      }
+    },
     componentDivisions(): MenuLink[] {
       return [
         {
@@ -57,9 +75,11 @@ export default {
   },
   methods: {
     async loadResult() {
+      this.resultLoading = true;
       this.$store.dispatch("scenario/addSunExposureLayer").then(() => {
         this.$store.commit("scenario/sunExposureLayer", true);
         this.sunExposureLoaded = true;
+        this.resultLoading = false;
       });
     },
   },
@@ -101,16 +121,12 @@ export default {
               Hours of sunlight per day averaged over a year
             </header>
           </div>
-          <v-btn @click="loadResult()" class="confirm_btn mt-2">
+          <v-btn @click="loadResult()" class="confirm_btn mt-2" :disabled="resultLoading">
             Run Scenario
           </v-btn>
         </v-container>
       </div>
       <!--component_content end-->
-      <v-overlay :value="resultLoading">
-        <div>Loading results</div>
-        <v-progress-linear style="margin-top: 50px">...</v-progress-linear>
-      </v-overlay>
     </div>
     <!--division end-->
 

--- a/src/components/Scenario/Wind.vue
+++ b/src/components/Scenario/Wind.vue
@@ -1,40 +1,130 @@
 <script lang="ts">
-import { generateStoreGetterSetter } from "@/store/utils/generators.ts";
-import hash from "object-hash";
 import Legend from "@/components/Scenario/Legend.vue";
 import MenuComponentDivision from "@/components/Menu/MenuComponentDivision.vue";
-import type { MenuLink } from "@/models";
-import { hideAllLayersButThese, removeSourceAndItsLayersFromMap } from '@/services/map.service';
-import { mapState } from 'vuex';
+import { Component, Vue } from "vue-property-decorator";
+import { Store } from "vuex";
+import { SavedWindScenarioConfiguration, StoreStateWithModules } from "@/models";
+import type { MenuLink, WindScenarioConfiguration, WindResult } from "@/models";
+import { defaultWindScenarioConfigs } from "@/store/wind";
+import * as calcModules from "@/services/calculationModules.service";
 
-export default {
-  name: "WindScenario",
-  components: {
-    Legend,
-    MenuComponentDivision,
-  },
-  data() {
-    return {
-      activeDivision: null,
-      windSpeed: 5,
-      windDirection: 270,
-      resultOutdated: true,
-      showError: false,
-      scenarioAlreadySaved: false,
-    };
-  },
-  computed: {
-    //...mapState('scenario', ['resultLoading']), // getter only
-    ...mapState(["map"]),
-    // syntax for storeGetterSetter [variableName, get path, ? optional custom commit path]
-    ...generateStoreGetterSetter([
-      ["windScenarioHash", "scenario/" + "windScenarioHash"], // todo wind store
-      ["resultLoading", "scenario/" + "resultLoading"], // todo manage stores
-      ["savedWindScenarios", "scenario/" + "savedWindScenarios"], // todo manage stores
-      ["currentScenario", "scenario/" + "currentWindScenario"], // todo manage stores
-    ]),
-    componentDivisions(): MenuLink[] {
-      return [
+
+@Component({
+  components: { MenuComponentDivision },
+})
+
+export default class WindScenario extends Vue {
+  $store: Store<StoreStateWithModules>;
+  activeDivision = null;
+  errMsg = "";
+  
+  scenarioConfiguration: WindScenarioConfiguration | null = null;
+
+
+  /** LIFE CYCLE   */
+  mounted(): void {
+    this.scenarioConfiguration = { ...this.scenarioConfigurationGlobal };
+    // hide all other layers
+    this.$store.dispatch("hideAllLayersButThese", ["wind"]);
+  }
+
+  /** METHODS */
+  // prop path is the path to the property inside the file that shall be updated. in this case the scenario description
+  // for our scenario name "scenario_1"
+  runScenario(): void {
+    // update wind scenario in store
+    this.scenarioConfigurationGlobal = Object.assign(
+      {},
+      this.scenarioConfiguration
+    );
+    this.calculateWindResult();
+  }
+
+  async calculateWindResult() {
+    this.errMsg = "";
+    this.$store.commit("wind/resetResult");
+    this.$store
+      .dispatch("wind/triggerWindCalculation")
+      .then(() => {
+        this.displayNewWindResults()
+      })
+  }
+    
+    // is busy until all result complete 
+  async displayNewWindResults() {
+    // TODO do we need to check if activeComponent is wind? onDestroy?
+    this.resultLoading = true;
+    const resultComplete = await this.$store
+      .dispatch("wind/updateWindResult")
+        .then(() => {
+        // success
+        return this.windResult.complete
+        })
+        .catch((err) => {
+          // fail
+          this.$store.commit("scenario/windLayer", false);
+          this.$store.dispatch("removeSourceFromMap", "wind", { root: true });
+          this.resultLoading = false;
+          this.errMsg = err;
+        });
+
+    // keep getting the wind result until it is complete
+    if (resultComplete === false) {
+      await new Promise((resolve) => setTimeout(resolve, 3000));
+      this.displayNewWindResults()
+    } else {
+      // when complete or error turn off result loading overlay
+      this.resultLoading = false;
+    }
+  }
+    
+  loadSavedScenario(savedScenario: SavedWindScenarioConfiguration): void {
+    this.scenarioConfiguration.wind_speed = savedScenario.wind_speed;
+    this.scenarioConfiguration.wind_direction = savedScenario.wind_direction;
+    
+    this.runScenario()
+  }
+
+  saveWindScenario() {
+    if (!this.isScenarioAlreadySaved) {
+      // add current scenario to saved scenarios
+      this.$store.commit("wind/addSavedScenarioConfiguration", this.scenarioConfiguration)
+    }
+  }
+  
+
+  /** GETTER / SETTER FOR GLOBAL VARIABLES FROM STORE */
+  // is changed via "addSavedScenario Mutation"
+  get savedScenarioConfigurations(): SavedWindScenarioConfiguration[] {
+    return this.$store.getters["wind/savedScenarioConfigurations"];
+  }
+  
+  get windResult(): WindResult {
+    return this.$store.getters["wind/windResult"];
+  }
+  
+  get scenarioConfigurationGlobal(): WindScenarioConfiguration {
+    return this.$store.getters["wind/scenarioConfiguration"];
+  }
+  set scenarioConfigurationGlobal(
+    newScenarioConfiguration: WindScenarioConfiguration
+  ) {
+    this.$store.commit(
+      "wind/mutateScenarioConfiguration",
+      newScenarioConfiguration
+    );
+  }
+
+  get resultLoading(): boolean {
+    return this.$store.state.scenario.resultLoading;
+  }
+  set resultLoading(loadingState: boolean) {
+    this.$store.commit("scenario/resultLoading", loadingState);
+  }
+
+  /** GETTERS FOR LOCAL VARIABLES */
+  get componentDivisions(): MenuLink[] {
+    return [
         {
           title: "Scenario",
           icon: "mdi-map-marker-radius",
@@ -50,103 +140,29 @@ export default {
           icon: "mdi-information-variant",
         },
       ];
-    },
-  },
-  watch: {
-    windSpeed(newVal, old) {
-      console.log("wind speed changed");
-      console.log(newVal);
-      this.resultOutdated = this.isResultOutdated();
-      this.scenarioAlreadySaved = this.isScenarioAlreadySaved();
-      console.log("is outdated?", this.isResultOutdated());
-      console.log("saved scen", this.currentScenario);
-    },
-    windDirection(newVal, old) {
-      console.log("wind direction changed");
-      console.log(newVal);
-      this.resultOutdated = this.isResultOutdated();
-      this.scenarioAlreadySaved = this.isScenarioAlreadySaved();
-    },
-  },
-  mounted: function () {
-    // hide all other layers
-    hideAllLayersButThese(this.map, ["wind"]);
-  },
-  methods: {
-    isResultOutdated() {
-      return (
-        this.windSpeed !== this.currentScenario["wind_speed"] ||
-        this.windDirection !== this.currentScenario["wind_direction"]
-      );
-    },
-    // prop path is the path to the property inside the file that shall be updated. in this case the scenario description
-    // for our scenario name "scenario_1"
-    confirmWindScenario() {
-      const fileName = "wind_scenario";
-      const propPath = ["scenario_1"];
-      this.currentScenario = {
-        wind_speed: this.windSpeed,
-        wind_direction: this.windDirection,
-        result_format: "geojson",
-        custom_roi: [],
-      };
-      this.windScenarioHash = hash(this.currentScenario); // todo use store variable
-      this.currentScenario["hash"] = this.windScenarioHash;
-      console.log(hash);
-      console.log("saved scenari", this.currentScenario);
+  }
 
-      this.getWindResults();
-      // update scenario add cityPyo
-      //this.$store.state.cityPyO.addLayerData(fileName, propPath, this.currentScenario).then(() => this.getWindResults())
-    },
-    async getWindResults() {
-      this.resultLoading = true;
-      removeSourceAndItsLayersFromMap("wind", this.map)
-      this.$store.commit("scenario/windResultGeoJson", null);
-      this.$store
-        .dispatch("scenario/updateWindLayer", this.currentScenario)
-        .then(() => {
-          // success
-          this.$store.commit("scenario/windLayer", true);
-          this.resultLoading = false;
-          this.resultOutdated = this.isResultOutdated();
-          this.scenarioAlreadySaved = this.isScenarioAlreadySaved();
-        })
-        .catch(() => {
-          // fail
-          this.$store.commit("scenario/windLayer", false);
-          this.resultLoading = false;
-          this.showError = true;
-        });
-    },
-    loadSavedScenario(savedScenario) {
-      this.windDirection = savedScenario["wind_direction"];
-      this.windSpeed = savedScenario["wind_speed"];
-      this.confirmWindScenario();
-    },
-    saveWindScenario() {
-      console.log("saved scenarios", this.savedWindScenarios);
-      if (!this.scenarioAlreadySaved) {
-        // add current scenario to saved scenarios
-        this.savedWindScenarios.push(this.currentScenario);
-      }
-      // update scenarioAlreadySaved variable
-      this.scenarioAlreadySaved = this.isScenarioAlreadySaved();
-      console.log(this.savedWindScenarios);
-    },
-    isScenarioAlreadySaved() {
+  get isFormDirty(): boolean {
+    return (
+      JSON.stringify(this.scenarioConfiguration) !==
+      JSON.stringify(this.scenarioConfigurationGlobal)
+    );
+  }
+
+  get isScenarioAlreadySaved() {
+      const savedScenarios = this.savedScenarioConfigurations;
       const isSaved =
-        this.savedWindScenarios.filter((savedScen) => {
+        savedScenarios
+        .filter((savedScen: SavedWindScenarioConfiguration) => {
           return (
-            JSON.stringify(savedScen) === JSON.stringify(this.currentScenario)
+            savedScen.wind_speed === this.scenarioConfiguration.wind_speed
+            && savedScen.wind_direction === this.scenarioConfiguration.wind_direction
           );
         }).length > 0;
 
-      console.log("is saved", isSaved);
       return isSaved;
-    },
-  },
-};
+  }
+}
 </script>
 
 <template>
@@ -173,13 +189,13 @@ export default {
         <v-container fluid>
           <h2>Wind Comfort | Scenario Settings</h2>
           <!-- Wind Direction -->
-          <div class="scenario_box" :class="resultOutdated ? 'highlight' : ''">
+          <div class="scenario_box" :class="isFormDirty ? 'highlight' : ''">
             <header class="text-sm-left">
               WIND DIRECTION
-              {{ windDirection }}°
+              {{ scenarioConfiguration.wind_direction }}°
             </header>
             <v-slider
-              v-model="windDirection"
+              v-model="scenarioConfiguration.wind_direction"
               step="15"
               thumb-label="always"
               thumb-size="25"
@@ -217,13 +233,13 @@ export default {
               flat
             ></v-slider>
           </div>
-          <div class="scenario_box" :class="resultOutdated ? 'highlight' : ''">
+          <div class="scenario_box" :class="isFormDirty ? 'highlight' : ''">
             <header class="text-sm-left">
               WIND SPEED
-              {{ windSpeed }} km/h
+              {{ scenarioConfiguration.wind_speed }} km/h
             </header>
             <v-slider
-              v-model="windSpeed"
+              v-model="scenarioConfiguration.wind_speed"
               step="5"
               thumb-label="always"
               thumb-size="25"
@@ -254,14 +270,14 @@ export default {
               flat
             ></v-slider>
           </div>
-          <p v-if="showError" class="warning">
-            Wind server not available at the moment
+          <p v-if="errMsg" class="warning">
+            {{ errMsg }}
           </p>
           <v-btn
-            @click="confirmWindScenario"
+            @click="runScenario"
             class="confirm_btn mt-2"
-            :class="{ changesMade: resultOutdated }"
-            :disabled="resultLoading || showError"
+            :class="{ changesMade: isFormDirty }"
+            :disabled="resultLoading"
           >
             RUN SCENARIO
           </v-btn>
@@ -274,8 +290,8 @@ export default {
             "
             @click="saveWindScenario"
             class="confirm_btn"
-            :disabled="resultOutdated || scenarioAlreadySaved"
-            :dark="resultOutdated || scenarioAlreadySaved"
+            :disabled="isFormDirty || isScenarioAlreadySaved"
+            :dark="isFormDirty || isScenarioAlreadySaved"
           >
             Save
           </v-btn>
@@ -284,14 +300,13 @@ export default {
           <div class="saved_scenarios" style="margin-top: 5vh">
             <h4>RELOAD A SAVED SCENARIO</h4>
             <v-data-iterator
-              :items="savedWindScenarios"
+              :items="savedScenarioConfigurations"
               :hide-default-footer="true"
             >
               <template v-slot:default="{ items }">
                 {{/* Use the items to iterate */}}
                 <v-flex v-for="(scenario, index) in items" :key="index">
                   <v-btn
-                    v-if="index <= 2"
                     style="margin: 1vh auto"
                     @click="loadSavedScenario(scenario)"
                     outlined

--- a/src/components/Scenario/Wind.vue
+++ b/src/components/Scenario/Wind.vue
@@ -67,7 +67,6 @@ export default class WindScenario extends Vue {
           // hide the wind layer, if the user meanwhile has switched to another component 
           if (!this.activeComponentIsWind) {
             hideLayers(this.map, [WindResultLayerConfig.layerConfig.id])
-            alert("Wind is ready")
           }
       })
       .catch((err) => {

--- a/src/components/Scenario/Wind.vue
+++ b/src/components/Scenario/Wind.vue
@@ -21,8 +21,6 @@ import ScenarioComponentNames from '@/config/scenarioComponentNames';
 export default class WindScenario extends Vue {
   $store: Store<StoreStateWithModules>;
   activeDivision = null;
-  errMsg = "";
-  
   scenarioConfiguration: WindScenarioConfiguration | null = null;
 
 
@@ -50,6 +48,10 @@ export default class WindScenario extends Vue {
     this.$store.dispatch("wind/triggerCalculation")
       .then(() => { 
         this.waitForResults() 
+      })
+      .catch(() => {
+          // fail
+          this.errMsg = "Failed to trigger calculation. Try again.";
       })
   }
     
@@ -105,15 +107,10 @@ export default class WindScenario extends Vue {
       this.$store.commit("wind/addSavedScenarioConfiguration", this.scenarioConfiguration)
     }
   }
-  
 
   /** GETTER / SETTER FOR GLOBAL VARIABLES FROM STORE */
   get map(): MapboxMap {
     return this.$store.state.map;
-  }
-
-  get activeComponentIsWind(): boolean {
-      return this.$store.state.activeMenuComponent === ScenarioComponentNames.wind;
   }
 
   get savedScenarioConfigurations(): SavedWindScenarioConfiguration[] {
@@ -123,7 +120,7 @@ export default class WindScenario extends Vue {
   get windResult(): WindResult {
     return this.$store.getters["wind/windResult"];
   }
-  
+
   get scenarioConfigurationGlobal(): WindScenarioConfiguration {
     return this.$store.getters["wind/scenarioConfiguration"];
   }
@@ -147,6 +144,14 @@ export default class WindScenario extends Vue {
     );
     loadingStati.wind = loadingState;
     this.$store.commit("scenario/resultLoadingStati", loadingStati);
+  }
+  
+  get errMsg(): string {
+    return this.$store.state.wind.errMsg;
+  }
+
+  set errMsg(msg: string) {
+    this.$store.commit("wind/mutateErrMsg", msg);
   }
 
   /** GETTERS FOR LOCAL VARIABLES */
@@ -188,6 +193,10 @@ export default class WindScenario extends Vue {
         }).length > 0;
 
       return isSaved;
+  }
+
+  get activeComponentIsWind(): boolean {
+      return this.$store.state.activeMenuComponent === ScenarioComponentNames.wind;
   }
 }
 </script>

--- a/src/components/Scenario/Wind.vue
+++ b/src/components/Scenario/Wind.vue
@@ -57,7 +57,6 @@ export default class WindScenario extends Vue {
     
   // is busy until result complete 
   async waitForResults() {
-    // TODO do we need to check if activeComponent is wind? onDestroy?
     this.resultLoading = true;
     this.$store.dispatch("wind/fetchResult")
       .then(() => {
@@ -74,6 +73,8 @@ export default class WindScenario extends Vue {
           this.$store.commit("scenario/windLayer", false); // // this is for the layer menu in the viewba
           removeSourceAndItsLayersFromMap("wind", this.map);
           this.errMsg = err;
+          console.error(err.stack);
+          //debugger;
       })
       .finally(() => {
         this.resultLoading = false;
@@ -186,8 +187,8 @@ export default class WindScenario extends Vue {
         savedScenarios
         .filter((savedScen: SavedWindScenarioConfiguration) => {
           return (
-            savedScen.wind_speed === this.scenarioConfiguration.wind_speed
-            && savedScen.wind_direction === this.scenarioConfiguration.wind_direction
+            savedScen.wind_speed === this.scenarioConfigurationGlobal.wind_speed
+            && savedScen.wind_direction === this.scenarioConfigurationGlobal.wind_direction
           );
         }).length > 0;
 
@@ -318,6 +319,8 @@ export default class WindScenario extends Vue {
           >
             RUN SCENARIO
           </v-btn>
+          
+        <v-card-actions class="d-flex flex-column">
           <v-btn
             style="
               margin-top: 1vh;
@@ -326,12 +329,27 @@ export default class WindScenario extends Vue {
               max-width: 30px;
             "
             @click="saveWindScenario"
-            class="confirm_btn"
+            class="confirm_btn ml-auto"
             :disabled="isFormDirty || isScenarioAlreadySaved || resultLoading"
-            :dark="isFormDirty || isScenarioAlreadySaved"
-          >
-            Save
+            :dark="isScenarioAlreadySaved"
+          >         
+          SAVE
           </v-btn>
+          <span v-if="isScenarioAlreadySaved"
+            class="ml-auto"
+            style="font-weight: bold;"
+          >Already saved
+          </span>
+          <span
+            class="ml-auto"
+            style="font-weight: bold;"
+          >
+            Showing results for: {{ scenarioConfigurationGlobal.wind_speed }}km/h | {{ scenarioConfigurationGlobal.wind_direction}}°
+          </span>
+          
+          
+        </v-card-actions>
+
 
           <!--saved scenarios -->
           <div class="saved_scenarios" style="margin-top: 5vh">
@@ -343,22 +361,29 @@ export default class WindScenario extends Vue {
               <template v-slot:default="{ items }">
                 {{/* Use the items to iterate */}}
                 <v-flex v-for="(scenario, index) in items" :key="index">
-                  <v-btn
-                    style="margin: 1vh auto"
-                    @click="loadSavedScenario(scenario)"
-                    outlined
-                    dark
-                    small
-                    :disabled="resultLoading"
-                  >
-                    <span v-if="scenario.label">
-                      {{ scenario.label }}
-                    </span>
-                    <span v-if="!scenario.label">
-                      Direction: {{ scenario.wind_direction }} | Speed:
-                      {{ scenario.wind_speed }}
-                    </span>
-                  </v-btn>
+                <v-tooltip left>
+                    <template v-slot:activator="{ on, attrs }">
+                    <v-btn
+                      style="margin: 1vh auto"
+                      @click="loadSavedScenario(scenario)"
+                      outlined
+                      dark
+                      small
+                      :disabled="resultLoading"
+                      v-bind="attrs"
+                      v-on="on"
+                      >
+                        <span v-if="scenario.label">
+                          {{ scenario.label }}
+                        </span>
+                        <span v-if="!scenario.label">
+                          Direction: {{ scenario.wind_direction }} | Speed:
+                          {{ scenario.wind_speed }}
+                        </span>
+                      </v-btn>
+                    </template>
+                    <span>{{ scenario.wind_speed }}km/h | {{ scenario.wind_direction}}°</span>
+                </v-tooltip>
                 </v-flex>
               </template>
             </v-data-iterator>

--- a/src/components/Scenario/Wind.vue
+++ b/src/components/Scenario/Wind.vue
@@ -29,6 +29,7 @@ export default class WindScenario extends Vue {
   }
 
   /** METHODS */
+  
   // prop path is the path to the property inside the file that shall be updated. in this case the scenario description
   // for our scenario name "scenario_1"
   runScenario(): void {

--- a/src/components/Scenario/Wind.vue
+++ b/src/components/Scenario/Wind.vue
@@ -8,7 +8,7 @@ import { MapboxMap, SavedWindScenarioConfiguration, StoreStateWithModules } from
 import type { MenuLink, WindScenarioConfiguration, WindResult, GeoJSON } from "@/models";
 import { defaultWindScenarioConfigs } from "@/store/wind";
 import * as calcModules from "@/services/calculationModules.service";
-import { addSourceAndLayerToMap, hideAllLayersButThese, removeSourceAndItsLayersFromMap } from "@/services/map.service";
+import { addSourceAndLayerToMap, hideAllLayersButThese, hideLayers, removeSourceAndItsLayersFromMap } from "@/services/map.service";
 import WindResultLayerConfig from "@/config/calculationModuleResults/windResultLayerConfig"
 import DashboardCharts from "./DashboardCharts.vue";
 import ScenarioComponentNames from '@/config/scenarioComponentNames';
@@ -62,6 +62,11 @@ export default class WindScenario extends Vue {
         // success
           this.$store.commit("scenario/windLayer", true); // this is for the layer menu in the viewbar
           this.addResultToMap(this.windResult.geojson)
+          // hide the wind layer, if the user meanwhile has switched to another component 
+          if (!this.activeComponentIsWind) {
+            hideLayers(this.map, [WindResultLayerConfig.layerConfig.id])
+            alert("Wind is ready")
+          }
       })
       .catch((err) => {
           // fail
@@ -105,6 +110,10 @@ export default class WindScenario extends Vue {
   /** GETTER / SETTER FOR GLOBAL VARIABLES FROM STORE */
   get map(): MapboxMap {
     return this.$store.state.map;
+  }
+
+  get activeComponentIsWind(): boolean {
+      return this.$store.state.activeMenuComponent === ScenarioComponentNames.wind;
   }
 
   get savedScenarioConfigurations(): SavedWindScenarioConfiguration[] {

--- a/src/config/scenarioComponentNames.ts
+++ b/src/config/scenarioComponentNames.ts
@@ -1,0 +1,12 @@
+import type { ScenarioComponentNames } from "@/models";
+
+const scenarioComponentNames: ScenarioComponentNames = {
+    "wind": "wind",
+    "sun": "sun",
+    "noise": "noise",
+    "stormwater": "stormwater",
+    "pedestrian": "pedestrian",
+    "multiLayer": "multiLayer",
+}
+
+export default scenarioComponentNames;

--- a/src/models.ts
+++ b/src/models.ts
@@ -1,6 +1,7 @@
 import type { Layer, Map as MapboxMap } from "mapbox-gl";
 import CityPyOStore from "./store/cityPyO";
 import type StormWater from "./store/stormwater";
+import type Wind from "./store/wind";
 
 export type { MapboxMap };
 export type GeoJSON = Record<string, unknown>;
@@ -66,6 +67,15 @@ export type StormWaterRoofType = "extensive" | "intensive";
 
 export type StormWaterFlowPath = "blockToPark" | "blockToStreet";
 
+export interface WindScenarioConfiguration {
+  windSpeed: number;
+  windDirection: number;
+}
+
+export interface WindResult {
+  geojson: GeoJSON;
+  complete: boolean;
+}
 export interface StormWaterScenarioConfiguration {
   returnPeriod: number;
   flowPath: StormWaterFlowPath;
@@ -73,7 +83,7 @@ export interface StormWaterScenarioConfiguration {
 }
 
 export interface StormWaterResult {
-  geojson: GenericObject;
+  geojson: GeoJSON;
   rainData: number[];
   complete: boolean;
 }
@@ -83,6 +93,7 @@ export type ScenarioWithTimeSheets = "abm" | "sw";
 export interface StoreStateWithModules extends StoreState {
   scenario: ScenarioStoreState;
   stormwater: StormWater;
+  wind: Wind;
 }
 
 export interface Legend {

--- a/src/models.ts
+++ b/src/models.ts
@@ -68,13 +68,18 @@ export type StormWaterRoofType = "extensive" | "intensive";
 export type StormWaterFlowPath = "blockToPark" | "blockToStreet";
 
 export interface WindScenarioConfiguration {
-  windSpeed: number;
-  windDirection: number;
+  wind_speed: number;
+  wind_direction: number;
+}
+
+export interface SavedWindScenarioConfiguration extends WindScenarioConfiguration{
+  label: string;
 }
 
 export interface WindResult {
   geojson: GeoJSON;
   complete: boolean;
+  tasksCompleted: number
 }
 export interface StormWaterScenarioConfiguration {
   returnPeriod: number;
@@ -128,7 +133,7 @@ export interface CityPyO {
   userid: string;
 }
 
-export interface CityPyOTask {
+export interface CalculationTask {
   taskId: string;
 }
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -78,8 +78,6 @@ export interface SavedWindScenarioConfiguration extends WindScenarioConfiguratio
 
 export interface WindResult {
   geojson: GeoJSON;
-  complete: boolean;
-  tasksCompleted: number
 }
 export interface StormWaterScenarioConfiguration {
   returnPeriod: number;
@@ -90,7 +88,6 @@ export interface StormWaterScenarioConfiguration {
 export interface StormWaterResult {
   geojson: GeoJSON;
   rainData: number[];
-  complete: boolean;
 }
 
 export type ScenarioWithTimeSheets = "abm" | "sw";

--- a/src/models.ts
+++ b/src/models.ts
@@ -2,6 +2,7 @@ import type { Layer, Map as MapboxMap } from "mapbox-gl";
 import CityPyOStore from "./store/cityPyO";
 import type StormWater from "./store/stormwater";
 import type Wind from "./store/wind";
+import ComponentNames from "@/config/scenarioComponentNames"
 
 export type { MapboxMap };
 export type GeoJSON = Record<string, unknown>;
@@ -28,7 +29,7 @@ export interface View {
 
 export interface StoreState {
   map: MapboxMap | null;
-  activeMenuComponent: string;
+  activeMenuComponent: ScenarioComponentName;
   allFeaturesHighlighted: boolean;
   showLegend: boolean;
   currentTime: number;
@@ -60,11 +61,15 @@ export interface ScenarioStoreState {
   abmSimpleTimes: Record<any, any>;
   currentTimeStamp: number;
   selectGraph: ScenarioWithTimeSheets;
-  resultLoading: boolean;
+  resultLoadingStati: DataLoadingStati;
 }
 
-export type StormWaterRoofType = "extensive" | "intensive";
+export type ScenarioComponentName = "wind" | "sun" | "stormwater" | "noise" | "pedestrian" | "multiLayer";
+export type ScenarioComponentNames = Record<ScenarioComponentName, ScenarioComponentName>;
 
+export type DataLoadingStati = Record<ScenarioComponentName | "map", boolean>;
+
+export type StormWaterRoofType = "extensive" | "intensive";
 export type StormWaterFlowPath = "blockToPark" | "blockToStreet";
 
 export interface WindScenarioConfiguration {

--- a/src/services/calculationModules.service.ts
+++ b/src/services/calculationModules.service.ts
@@ -96,8 +96,6 @@ export async function requestCalculationStormWater(
 export async function getResultForWind({
   taskId,
 }: CalculationTask): Promise<WindResult> {
-  // TODO make groupTask object
-
   // first get result object for parent task -> returns a groupTask
   const groupTaskResult = await getResultWhenReady(
     config.endpointsResultCollection["wind_single_task"],

--- a/src/services/calculationModules.service.ts
+++ b/src/services/calculationModules.service.ts
@@ -99,7 +99,7 @@ export async function getResultForWind({
   // TODO make groupTask object
 
   // first get result object for parent task -> returns a groupTask
-  const groupTask = await getResultWhenReady(
+  const groupTaskResult = await getResultWhenReady(
     config.endpointsResultCollection["wind_single_task"],
     taskId
   );
@@ -107,19 +107,19 @@ export async function getResultForWind({
   // get results for tasks in groupTask
   const result = await getResultWhenReady(
     config.endpointsResultCollection.wind_group_task,
-    groupTask["result"]
+    groupTaskResult
   ).then((result) => {
     return result;
   });
 
   // check result validity
-  if (!result["results"]) {
+  if (!result["features"]) {
     console.error("Invalid result", result);
     throw new Error("Did not get a valid result");
   }
 
   return  {
-    geojson: result["results"]
+    geojson: result
   };
 }
 
@@ -132,12 +132,12 @@ export async function getResultForNoise(task: GenericObject): Promise<GeoJSON> {
   );
 
   // check result validity
-  if (!result) {
+  if (!result["features"]) {
     console.error("Invalid result", result);
     throw new Error("Did not get a valid result");
   }
 
-  return result["result"]
+  return result
 }
 
 /** gets stormwater result */
@@ -157,8 +157,8 @@ export async function getResultForStormWater(
   }
 
   return {
-    geojson: result["result"]["geojson"], // geojson with subcatchments to be shown as map layer
-    rainData: result["result"]["rain"], // rain data to be shown in time TimeSheet
+    geojson: result["geojson"], // geojson with subcatchments to be shown as map layer
+    rainData: result["rain"], // rain data to be shown in time TimeSheet
   };
 }
 
@@ -188,7 +188,7 @@ async function getResultWhenReady(url, taskUuid) {
     for await (const response of generator) {
       result_ready = response["resultReady"] || response["grouptaskProcessed"]  // TODO rename at endpoint
       if (result_ready) {
-        return response;
+        return response["result"] || response["results"];  // "results" for group tasks 
       }
     }
     console.error("could not get result for url, uuid", url, taskUuid);

--- a/src/store/actions.ts
+++ b/src/store/actions.ts
@@ -10,11 +10,7 @@ import { ActionContext } from "vuex";
 export default {
   async createDesignLayers({
     state,
-    commit,
   }: ActionContext<StoreState, StoreState>) { 
-    commit("scenario/loader", true);
-    commit("scenario/loaderTxt", "Creating Design Layers ... ");
-
     const designConfigs = [...BuildingLayerConfigs, LandscapeLayerConfig];
     // iterate over sources in configs
     designConfigs.forEach((config : SourceAndLayerConfig) => {
@@ -26,8 +22,6 @@ export default {
         addSourceAndLayerToMap(config.source, [config.layerConfig], state.map)
       });
     });
-    // finally remove loading screen
-    commit("scenario/loader", false);
   },
   addFocusAreasMapLayer({
     state,

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -11,6 +11,7 @@ import {
   generateSimpleMutations,
 } from "./utils/generators";
 import stormwater from "./stormwater";
+import wind from "./wind";
 
 Vue.use(Vuex);
 
@@ -18,6 +19,7 @@ const store = new Vuex.Store({
   modules: {
     scenario,
     stormwater,
+    wind
   },
   state,
   getters: {

--- a/src/store/scenario/actions.ts
+++ b/src/store/scenario/actions.ts
@@ -115,21 +115,14 @@ export default {
     { state, commit, dispatch, rootState },
     scenarioId: string
   ) {
-    //show loading screen
-    commit("resultLoading", true);
-    commit("loader", true);
-
     rootState.cityPyO.getLayer(scenarioId, false).then((result) => {
       if (!result) {
         alert(
           "There was an error requesting the data from the server. Please get in contact with the admins."
         );
-        //remove loading screen
-        commit("resultLoading", false);
         return;
       }
 
-      commit("loaderTxt", "Serving Abm Data ... ");
       return dispatch("computeLoop", result.data);
     });
 
@@ -183,22 +176,13 @@ export default {
     calculateAmenityStatsForFocusArea();
     calculateAbmStatsForFocusArea();
   },
-  async calculateStatsForMultiLayerAnalysis({
-    commit,
-  }) {
-    commit("resultLoading", true);
-    commit("loader", true);
-    commit("loaderTxt", "Calculating statistics for each focus area (slow)");
-
+  async calculateStatsForMultiLayerAnalysis({}) {
     // the timeout just gives time for the commits above to persist and the app to be rerendered
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    calculateAmenityStatsForMultiLayerAnalysis().then(() => {
-      calcAbmStatsForMultiLayer().then(() => {
-        commit("resultLoading", false);
-        commit("loader", false);
-        commit("loaderTxt", "loading");
-      });
+    await calculateAmenityStatsForMultiLayerAnalysis().then(() => {
+      calcAbmStatsForMultiLayer()
+      return;
     });
   },
   // load layer source from cityPyo and add the layer to the map
@@ -264,15 +248,10 @@ export default {
     { state, commit, dispatch, rootState },
     workshopScenario
   ) {
-    //show loading screen
-    commit("resultLoading", true);
-    commit("loader", true);
-
     //check if special workshop Scenario should be loaded
     const scenarioName = workshopScenario || abmTripsLayerName;
 
     //LOAD DATA FROM CITYPYO
-    commit("loaderTxt", "Getting ABM Simulation Data from CityPyO ... ");
     return rootState.cityPyO
       .getAbmResultLayer(scenarioName, state)
       .then((resultGeoJson: GeoJSON) => {
@@ -285,7 +264,6 @@ export default {
           return;
         }
 
-        commit("loaderTxt", "Serving Abm Data ... ");
         return dispatch("computeLoop", resultGeoJson).then(
           dispatch("calculateStatsForGrasbrook")
         );
@@ -301,7 +279,7 @@ export default {
     console.log("abmCore size: ", abmCore?.length);
     //go through each agent inside the abm set (agent, index, array)
 
-    commit("loaderTxt", "Clustering ABM Data for functional purposes ... ");
+    // Clustering ABM Data for functional purposes
     abmCore.forEach((who, index, array) => {
       const agent_id = who.agent.id;
 
@@ -320,7 +298,7 @@ export default {
       // #2 Clustering TIME DATA for Aggregation Layer
       // ---------------- TIME DATA ------------------------------
       // TODO refactor!!!
-      commit("loaderTxt", "Analyzing Time Data ... ");
+      // Analyzing Time Data
       who.timestamps.forEach((v, i, a) => {
         /*round timestamps to full hours*/
         const h = Math.floor(v / 3600) + 8;
@@ -342,7 +320,7 @@ export default {
 
         // TODO 300 ?? what is 300??
 
-        commit("loaderTxt", "Creating Simple Time Data Arrays ... ");
+        // Creating Simple Time Data Arrays
         simpleTimeData[Math.floor(v / 300) * 300] =
           simpleTimeData[Math.floor(v / 300) * 300] || {};
         simpleTimeData[Math.floor(v / 300) * 300]["all"] =
@@ -368,7 +346,7 @@ export default {
           who.agent.resident_or_visitor
         ].push(agent_id);
 
-        commit("loaderTxt", "Creating Busy Agents ... ");
+        // Creating Busy Agents
         if (i == 0) {
           timePaths[h].busyAgents.push(agent_id);
         }
@@ -391,11 +369,7 @@ export default {
     commit("activeAbmSet", Object.freeze(abmCore));
 
     //buildLayers
-    return dispatch("buildLayers").then(
-      // hide loading screen
-      commit("resultLoading", false),
-      commit("loader", false)
-    );
+    return dispatch("buildLayers");
   },
   buildLayers({ state, commit, dispatch, rootState }) {
     const tripsLayerData = state.activeAbmSet;

--- a/src/store/scenario/actions.ts
+++ b/src/store/scenario/actions.ts
@@ -110,53 +110,6 @@ export default {
       addSourceAndLayersToMap(SunExposure.source, [SunExposure.layerConfig], rootState.map)
     });
   },
-  // load layer source from cityPyo and add the layer to the map
-  // Todo : isnt there a way to update the source data without reinstanciating the entire layer?
-  async updateWindLayer(
-    { state, commit, dispatch, rootState },
-    wind_scenario
-  ): Promise<void> {
-    console.debug("updating wind!");
-    const { userid } = rootState.cityPyO;
-    wind_scenario["city_pyo_user"] = userid;
-    // fetch results, add to map and return boolean whether results are complete or not
-    const windResultUuid = await calculationModules.requestCalculationWind(
-      wind_scenario,
-      userid
-    );
-    console.debug("wind result uuid", windResultUuid);
-    const completed = await calculationModules
-      .getResultForWind(windResultUuid)
-      .then((resultInfo) => {
-        console.log("end result", resultInfo);
-
-        const receivedCompleteResult = resultInfo.complete || false; // was the result complete?
-        const source = resultInfo.source;
-
-        // results are new if they contain more features than the known result
-        const newResults =
-          !state.windResultGeoJson ||
-          source.options.data.features.length >
-            state.windResultGeoJson["features"].length;
-
-        if (receivedCompleteResult || newResults) {
-          // todo use timestamP??
-          // received an updated result
-          source.id = "wind";
-          commit("windResultGeoJson", Object.freeze(source.options.data));
-          // will be moved to wind service with rebase
-          WindResultLayerConfig.source.options.data = source.options.data;
-          addSourceAndLayersToMap(WindResultLayerConfig.source, [WindResultLayerConfig.layerConfig], rootState.map)
-        }
-        return receivedCompleteResult;
-      });
-
-    if (!completed) {
-      // keep fetching new results until the results are complete
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-      dispatch("updateWindLayer", wind_scenario);
-    }
-  },
   // TODO: how do we realize 1 central function for all users?
   loadScienceCityAbmScenario(
     { state, commit, dispatch, rootState },

--- a/src/store/scenario/actions.ts
+++ b/src/store/scenario/actions.ts
@@ -104,8 +104,8 @@ export default {
     commit,
   }: ActionContext<StoreState, StoreState>) {
     return rootState.cityPyO.getLayer("sun_exposure").then((result) => {
-      commit("sunExposureGeoJson", result.results);
-      SunExposure.source.options.data = result.results;
+      commit("sunExposureGeoJson", result);
+      SunExposure.source.options.data = result;
 
       addSourceAndLayersToMap(SunExposure.source, [SunExposure.layerConfig], rootState.map)
     });

--- a/src/store/scenario/multiLayerAnalysis.ts
+++ b/src/store/scenario/multiLayerAnalysis.ts
@@ -238,7 +238,7 @@ const noiseLookup = [45, 50, 55, 60, 65, 70, 75, 80];
 function layerLookup(layerName: string) {
   switch (layerName) {
     case "wind":
-      return store.getters["wind/windResult"];
+      return store.getters["wind/windResult"].geojson;
     case "sun":
       return store.state.scenario.sunExposureGeoJson;
     case "noise":

--- a/src/store/scenario/multiLayerAnalysis.ts
+++ b/src/store/scenario/multiLayerAnalysis.ts
@@ -238,7 +238,7 @@ const noiseLookup = [45, 50, 55, 60, 65, 70, 75, 80];
 function layerLookup(layerName: string) {
   switch (layerName) {
     case "wind":
-      return store.state.scenario.windResultGeoJson;
+      return store.getters["wind/windResult"];
     case "sun":
       return store.state.scenario.sunExposureGeoJson;
     case "noise":

--- a/src/store/scenario/state.ts
+++ b/src/store/scenario/state.ts
@@ -59,29 +59,7 @@ export default {
   amenityStats: {},
 
   // wind
-  windScenarioHash: "158d2b824886d908440da5c5f6c4dc4f815cdeba", // hash for annual average setting // TODO DELETE?
-  currentWindScenario: {
-    wind_speed: 5,
-    wind_direction: 270,
-  }, // only gets used to create a description string in "Combine Layers" menu so far.
-  savedWindScenarios: [
-    {
-      wind_speed: 5,
-      wind_direction: 270,
-      label: "ANNUAL AVERAGE",
-    },
-    {
-      wind_speed: 25,
-      wind_direction: 270,
-      label: "LIGHT BREEZE",
-    },
-    {
-      wind_speed: 45,
-      wind_direction: 270,
-      label: "STRONG BREEZE",
-    },
-  ],
-  windResultGeoJson: null,
+  windResultGeoJson: null,  // for multi layer analysis, TODO
 
   // sun
   sunExposureGeoJson: null,

--- a/src/store/scenario/state.ts
+++ b/src/store/scenario/state.ts
@@ -1,4 +1,16 @@
+import { DataLoadingStati } from '@/models';
 import { bridges, roofAmenitiesOptions } from "@/store/abm";
+
+
+const initialResultLoadingStati: DataLoadingStati = {
+  pedestrian: false,
+  sun: false,
+  wind: false,
+  multiLayer: false,
+  stormwater: false,
+  noise: false
+};
+
 
 export default {
   // ABM
@@ -49,10 +61,7 @@ export default {
   lastClick: [],
   showUi: true,
   allFeaturesHighlighted: false,
-  selectedFocusAreas: [],
-  resultLoading: false,
-  loader: true,
-  loaderTxt: "data is loading ... ",
+  selectedFocusAreas: [],  
 
   // Amenities
   amenitiesGeoJson: null,
@@ -73,6 +82,7 @@ export default {
 
   // UI
   selectGraph: "abm",
+  resultLoadingStati: initialResultLoadingStati,
 
   // Stormwater
   rainTime: 0,

--- a/src/store/scenario/state.ts
+++ b/src/store/scenario/state.ts
@@ -58,9 +58,6 @@ export default {
   amenitiesGeoJson: null,
   amenityStats: {},
 
-  // wind
-  windResultGeoJson: null,  // for multi layer analysis, TODO
-
   // sun
   sunExposureGeoJson: null,
 

--- a/src/store/state.ts
+++ b/src/store/state.ts
@@ -2,9 +2,10 @@ import Config from "@/config/config.json";
 import Defaults from "@/defaults";
 import { StoreState, View } from "@/models";
 
+
 const initialState: StoreState = {
   map: null,
-  activeMenuComponent: "AbmScenario",
+  activeMenuComponent: "pedestrian",
   allFeaturesHighlighted: false,
   showLegend: false,
   selectedMultiFeatures: [],

--- a/src/store/stormwater.ts
+++ b/src/store/stormwater.ts
@@ -43,8 +43,7 @@ export default class StormWaterStore extends VuexModule {
   mutateResult(newResult: StormWaterResult): void {
     this.result = {
       geojson: Object.freeze(newResult.geojson),
-      rainData: newResult.rainData,
-      complete: newResult.complete,
+      rainData: newResult.rainData
     };
   }
 

--- a/src/store/wind.ts
+++ b/src/store/wind.ts
@@ -103,35 +103,9 @@ export default class WindStore extends VuexModule {
     this.result = null;
   }
 
-  /** TODO 
-   * For multilayer analysis "addSubSelectionLayer" 
-   * we need to have possibility to only get result without displaying it. 
-   * 
-   * each module should implement these methods 
-   * "triggerCalculation -> CalculationTask"
-   * "fetch Results" -> Result (geojson, tasks_completed, taskCount)
-   * "task completed" => ( tasks_completed && tasks_completed === taskCount) -> boolean
-   * "Add results to map" -> void
-   * 
-   * 
-   * // Mutations
-   * mutateScenarioConfig
-   * addSavedScenarioConfig
-   * mutateResult
-   * 
-   * // getters
-   * scenarioConfig
-   * savedScenarioConfigs
-   * calcTask
-   * isResultComplete
-   * getResult
-   * 
-   * */
-
-
   // TODO why is this working without a specified @Mutation method?? 
   @MutationAction({ mutate: ["calcTask"] })
-  async triggerWindCalculation(): Promise<{ calcTask: CalculationTask }> {
+  async triggerCalculation(): Promise<{ calcTask: CalculationTask }> {
     // request calculation and fetch results
     const task: CalculationTask = 
       await calcModules.requestCalculationWind(
@@ -140,26 +114,21 @@ export default class WindStore extends VuexModule {
     );
     return { calcTask: task };
   }
-
-  @MutationAction({ mutate: ["result"] })
-  async updateWindResult(): Promise<{ result: WindResult }> {
+    
+  @MutationAction({ mutate: ["result"] , rawError: true })
+  async fetchResult(): Promise<{ result: WindResult }> {
     const simulationResult: WindResult = await calcModules.getResultForWind(this.calculationTask);
 
-    // new result? then update wind layer
-    if (!this.windResult || (simulationResult.tasksCompleted > this.windResult.tasksCompleted)) {
-      this.context.dispatch("updateWindLayer", simulationResult)
-      this.context.commit("scenario/windLayer", true, {root: true}); // this is for the layer menu in the viewbar
-    }
     return { result: simulationResult };
   }
 
   @Action({})
-  async updateWindLayer(result: WindResult) {
+  async addResultToMap() {
     // delete old mapSource from map
     this.context.dispatch("removeSourceFromMap", WindLayer.mapSource.id, { root: true });
 
     // format result as map source
-    const mapSource = calcModules.formatResultAsMapSource(WindLayer.mapSource.id, result.geojson)
+    const mapSource = calcModules.formatResultAsMapSource(WindLayer.mapSource.id, this.result.geojson)
 
     // add new source and layer to map
     this.context.dispatch("addSourceToMap", mapSource, { root: true })

--- a/src/store/wind.ts
+++ b/src/store/wind.ts
@@ -13,7 +13,7 @@ import {
   MutationAction,
   VuexModule,
 } from "vuex-module-decorators";
-import WindLayer from "@/config/windLayer.json";
+import WindLayer from "@/config/calculationModuleResults/windResultLayerConfig";
 
 
 export const defaultWindConfiguration: WindScenarioConfiguration = {
@@ -121,19 +121,4 @@ export default class WindStore extends VuexModule {
 
     return { result: simulationResult };
   }
-
-  @Action({})
-  async addResultToMap() {
-    // delete old mapSource from map
-    this.context.dispatch("removeSourceFromMap", WindLayer.mapSource.id, { root: true });
-
-    // format result as map source
-    const mapSource = calcModules.formatResultAsMapSource(WindLayer.mapSource.id, this.result.geojson)
-
-    // add new source and layer to map
-    this.context.dispatch("addSourceToMap", mapSource, { root: true })
-      .then(() => {
-        this.context.dispatch("addLayerToMap", WindLayer.layer, { root: true })
-      });
-  }     
 }

--- a/src/store/wind.ts
+++ b/src/store/wind.ts
@@ -103,6 +103,33 @@ export default class WindStore extends VuexModule {
     this.result = null;
   }
 
+  /** TODO 
+   * For multilayer analysis "addSubSelectionLayer" 
+   * we need to have possibility to only get result without displaying it. 
+   * 
+   * each module should implement these methods 
+   * "triggerCalculation -> CalculationTask"
+   * "fetch Results" -> Result (geojson, tasks_completed, taskCount)
+   * "task completed" => ( tasks_completed && tasks_completed === taskCount) -> boolean
+   * "Add results to map" -> void
+   * 
+   * 
+   * // Mutations
+   * mutateScenarioConfig
+   * addSavedScenarioConfig
+   * mutateResult
+   * 
+   * // getters
+   * scenarioConfig
+   * savedScenarioConfigs
+   * calcTask
+   * isResultComplete
+   * getResult
+   * 
+   * */
+
+
+  // TODO why is this working without a specified @Mutation method?? 
   @MutationAction({ mutate: ["calcTask"] })
   async triggerWindCalculation(): Promise<{ calcTask: CalculationTask }> {
     // request calculation and fetch results
@@ -122,7 +149,6 @@ export default class WindStore extends VuexModule {
     if (!this.windResult || (simulationResult.tasksCompleted > this.windResult.tasksCompleted)) {
       this.context.dispatch("updateWindLayer", simulationResult)
       this.context.commit("scenario/windLayer", true, {root: true}); // this is for the layer menu in the viewbar
-      this.context.commit("scenario/windResultGeoJson", Object.freeze(simulationResult.geojson), {root: true});  // TODO replace all usages of this with wind store
     }
     return { result: simulationResult };
   }

--- a/src/store/wind.ts
+++ b/src/store/wind.ts
@@ -93,8 +93,6 @@ export default class WindStore extends VuexModule {
   mutateResult(newResult: WindResult): void {
     this.result = {
       geojson: Object.freeze(newResult.geojson),
-      complete: newResult.complete,
-      tasksCompleted: newResult.tasksCompleted
     };
   }
 

--- a/src/store/wind.ts
+++ b/src/store/wind.ts
@@ -1,0 +1,72 @@
+import type {
+  WindResult,
+  WindScenarioConfiguration,
+} from "@/models";
+import { cityPyOUserid } from "@/services/authn.service";
+import * as calcModules from "@/services/calculationModules.service";
+import {
+  Module,
+  Mutation,
+  MutationAction,
+  VuexModule,
+} from "vuex-module-decorators";
+
+export const defaultWindConfiguration: WindScenarioConfiguration = {
+  windDirection: 270,
+  windSpeed: 5
+};
+
+
+// TODO make an interface CalculationModuleStore which extends VuexModule ;
+//  Wind/Stormwater are then to extend CalculationModuleStore;
+@Module({ namespaced: true })
+export default class WindStore extends VuexModule {
+  scenarioConfig: WindScenarioConfiguration = {
+    ...defaultWindConfiguration,
+  };
+  result: WindResult | null = null;
+
+  get scenarioConfiguration(): WindScenarioConfiguration {
+    return this.scenarioConfig;
+  }
+
+  get windResult(): WindResult {
+    return this.result;
+  }
+
+  @Mutation
+  mutateScenarioConfiguration(
+    newScenarioConfiguration: WindScenarioConfiguration
+  ): void {
+    this.scenarioConfig = { ...newScenarioConfiguration };
+  }
+
+  @Mutation
+  mutateResult(newResult: WindResult): void {
+    this.result = {
+      geojson: Object.freeze(newResult.geojson),
+      complete: newResult.complete,
+    };
+  }
+
+  @Mutation
+  resetResult(): void {
+    this.result = null;
+  }
+
+  @MutationAction({ mutate: ["result"] })
+  async updateWindResult(): Promise<{ result: WindResult }> {
+    // request calculation and fetch results
+    const windResultUuid = await calcModules.requestCalculationWind(
+      this.scenarioConfiguration,
+      cityPyOUserid()
+    );
+
+    // TODO ignore for now, refactor wind update to use this function analog to stormwater
+    // @ts-ignore
+    const simulationResult: WindResult =
+      await calcModules.getResultForWind(windResultUuid);
+
+    return { result: simulationResult };
+  }
+}

--- a/src/store/wind.ts
+++ b/src/store/wind.ts
@@ -54,6 +54,8 @@ export default class WindStore extends VuexModule {
   
   result: WindResult | null = null;
 
+  errMsg: string = "";
+
   get scenarioConfiguration(): WindScenarioConfiguration {
     return this.scenarioConfig;
   }
@@ -70,6 +72,13 @@ export default class WindStore extends VuexModule {
     return this.result;
   }
 
+  @Mutation
+  mutateErrMsg(
+    msg: string
+  ): void {
+    this.errMsg = msg;
+  }
+  
   @Mutation
   mutateScenarioConfiguration(
     newScenarioConfiguration: WindScenarioConfiguration

--- a/src/typings.d.ts
+++ b/src/typings.d.ts
@@ -39,6 +39,8 @@ declare global {
     max_speed: number;
   }
 
+  
+
   interface AbmScenarioSettings {
     bridge_hafencity: boolean;
     bridge_veddel: "horizontal" | "diagonal";


### PR DESCRIPTION
Make wind component use it's own store.
@totev  : I tried to implement an interface for the calculation module stores, as they will share many functions (get result, update result, save scenario, ...) . But honestly interfaces do not seem to work the same way in JS.. Can you not implement/override functions ???? I feel so lost with this sometimes.